### PR TITLE
Not reset the form when loading an example

### DIFF
--- a/share/views/form.haml
+++ b/share/views/form.haml
@@ -44,7 +44,7 @@
             var link = $(this);
             var name = $(link).attr('name');
             var inputs = example_inputs[name];
-            form[0].reset()
+            //form[0].reset()
 
             for (var input in inputs){
               var value = inputs[input]


### PR DESCRIPTION
Move the example data to the top of the web or add a reset button but not reset the form when loading an example.